### PR TITLE
Allow the switch between filter and non-filter graphs

### DIFF
--- a/src/currentImplicit.tsx
+++ b/src/currentImplicit.tsx
@@ -33,6 +33,7 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
         var initialState = {
             selected: -1,
             // cgRef: React.createRef<ChartGalleryComponent>()
+            filterView: true,
         };
         this.state = initialState;
     }
@@ -51,7 +52,21 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
     // }
 
     onItemSelect(idx) {
-        console.log("on item select in implicit: " + idx)
+        console.log("on item select in implicit:" + idx)
+    }
+
+    switchFilterView(){
+        this.setState({
+            filterView: !this.state.filterView
+        });
+        for (var i = 1; i < this.props.recs[0].vspec.length; i++) {
+            if(this.state.filterView){
+                this.props.recs[0].vspec[i]["transform"] = [{"filter": {"field": "filt_mask", "equal": true}}];
+            } else {
+                delete this.props.recs[0].vspec[i]["transform"];
+            }
+        }
+        console.log("Change filter view to " + this.state.filterView)
     }
     render() {
         if (!_.isEmpty(this.props.recs)) {
@@ -82,18 +97,50 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
                 }
             }
 
+            var vspec = this.props.recs[0].vspec
+            // console.log("spec" + JSON.stringify(vspec[0]["encoding"]))
+            // for (var i = 1; i < vspec.length; i++) {
+            //     if("transform" in vspec[i]){
+            //         console.log("tranform " + JSON.stringify(vspec[i]["transform"]));
+            //     } else {
+            //         console.log("transform filter does not exist");
+            //     }
+            // }
+            var filterSwitchEnabled = (vspec.length > 0 && "encoding" in vspec[0] && "y" in vspec[0]["encoding"] && 
+                JSON.stringify(vspec[0]["encoding"]["y"]["title"]).substring(1, JSON.stringify(vspec[0]["encoding"]["y"]["title"]).length - 1) == "Filtered Data Count")
+
+            // the variable op_name is not a perfect indicator of when there will be a filter chart.
+            // the comman characteristic is that the first implicit vis should be a chart about filter count
+            // console.log("filterSwitchEnabled: " + filterSwitchEnabled)
+            let filterSwitch_UI;
+            if(filterSwitchEnabled) {
+                filterSwitch_UI = <Button style={{
+                                            fontSize: "13px",
+                                            minWidth: "0px",
+                                            textTransform: "none",
+                                            display: "float",
+                                            left: "70%",
+                                            top: "10px",
+                                            background: "lightyellow",
+                                        }}
+                                    onClick={this.switchFilterView.bind(this)}
+                                >Switch Filter View</Button>
+            }
             return (
                 <div id="mainVizContainer" style={mStyle}>
                     <div>
                         <div>
-                            <p className="title-description"
-                                style={{
-                                    position: 'absolute',
-                                    fontSize: '20px',
-                                    height: '25px',
-                                    display: 'inline',
-                                    top: '10px',
-                                }}>Implicit Visualization</p>
+                            <div className="title-button-box">
+                                <p className="title-description"
+                                    style={{
+                                        display: "float",
+                                        width: "50%",
+                                        fontSize: '20px',
+                                        height: '25px',
+                                        top: '10px',
+                                    }}>Implicit Visualization</p>
+                                {filterSwitch_UI}
+                            </div>
 
                             <p className="text-description"
                                 style={{

--- a/src/currentImplicit.tsx
+++ b/src/currentImplicit.tsx
@@ -59,10 +59,13 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
         this.setState({
             filterView: !this.state.filterView
         });
-        for (var i = 1; i < this.props.recs[0].vspec.length; i++) {
-            if(this.state.filterView){
+        if(this.state.filterView){
+            this.props.recs[0].vspec[0]["transform"] = [{"filter": {"field": "In filter?", "equal": true}}];
+            for (var i = 1; i < this.props.recs[0].vspec.length; i++) {
                 this.props.recs[0].vspec[i]["transform"] = [{"filter": {"field": "filt_mask", "equal": true}}];
-            } else {
+            }
+        } else {
+            for (var i = 0; i < this.props.recs[0].vspec.length; i++) {
                 delete this.props.recs[0].vspec[i]["transform"];
             }
         }

--- a/src/currentImplicit.tsx
+++ b/src/currentImplicit.tsx
@@ -52,7 +52,7 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
     // }
 
     onItemSelect(idx) {
-        console.log("on item select in implicit:" + idx)
+        console.log("on item select in implicit: " + idx)
     }
 
     switchFilterView(){
@@ -101,20 +101,19 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
             }
 
             var vspec = this.props.recs[0].vspec
-            // console.log("spec" + JSON.stringify(vspec[0]["encoding"]))
-            // for (var i = 1; i < vspec.length; i++) {
-            //     if("transform" in vspec[i]){
-            //         console.log("tranform " + JSON.stringify(vspec[i]["transform"]));
-            //     } else {
-            //         console.log("transform filter does not exist");
-            //     }
-            // }
-            var filterSwitchEnabled = (vspec.length > 0 && "encoding" in vspec[0] && "y" in vspec[0]["encoding"] && 
+            for (var i = 0; i < vspec.length; i++) {
+                if("encoding" in vspec[i]){
+                    console.log("tranform " + JSON.stringify(vspec[i]["encoding"]));
+                } else {
+                    console.log("encoding does not exist");
+                }
+            }
+            var filterSwitchEnabled = (vspec.length > 0 && "encoding" in vspec[0] && "y" in vspec[0]["encoding"] && "title" in vspec[0]["encoding"]["y"] &&
                 JSON.stringify(vspec[0]["encoding"]["y"]["title"]).substring(1, JSON.stringify(vspec[0]["encoding"]["y"]["title"]).length - 1) == "Filtered Data Count")
 
             // the variable op_name is not a perfect indicator of when there will be a filter chart.
             // the comman characteristic is that the first implicit vis should be a chart about filter count
-            // console.log("filterSwitchEnabled: " + filterSwitchEnabled)
+            console.log("filterSwitchEnabled: " + filterSwitchEnabled)
             let filterSwitch_UI;
             if(filterSwitchEnabled) {
                 filterSwitch_UI = <Button style={{
@@ -175,7 +174,7 @@ class CurrentImplicitComponent extends Component<currentVisProps, any> {
                             multiple={true}
                             maxSelectable={10}
                             onChange={this.onItemSelect.bind(this)}
-                            graphSpec={this.props.recs[0].vspec}
+                            graphSpec={vspec}
                             currentVisShow={false}
                         />
                     </div>


### PR DESCRIPTION
In the implementation, I intend to make as few changes as possible to the vega-lite specifications so that we do not need to keep a copy of the original specifications but in the meantime, we are able to switch between the filter view and non-filter view.  As a result, when the user switches off the filter graph, there are some noteworthy points.

- Since we do not want to change the number of specs, we still keep the first filter count graph but only shows the number of filtered data points instead. 
- For the other graphs, we still keep the legend `Is Filtered` even though all bars are blue (which means that they are all of the `true` group). Ideally, we should remove this unnecessary legend (which then involves removing the `colour` and `order` channel) but this seems good to me since it informs the user that current visualizations are of the filtered dataframe. 