### PR TITLE
Fixed the issue #32 in the lux lib (the LHS of the interface does not show)

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -455,7 +455,7 @@ export class LuxWidgetView extends DOMWidgetView {
             <div id="widgetContainer" style={{ flexDirection: 'column' }}>
               <div style={{ display: 'flex', flexDirection: 'row' }}>
 
-                {_.isEmpty(this.state.intent) ?
+                {(_.isEmpty(this.state.intent) && _.isEmpty(this.state.currentVis)) ?
                   <CurrentImplicitComponent
                     recs={this.state.implicitVisList}
                     op_name={op_name}


### PR DESCRIPTION
Even if the self.current_vis object is the bar chart of cylinders now, the left-hand side of the interface is still missing. This is because the LuxWidget only shows the `self.current_vis` object when the `self.intent` is not empty. Otherwise, it will show the `this.state.implicitVisList` instead. I am considering replacing the condition as `_.isEmpty(this.state.intent) & _.isEmpty(this.state.currentVis)`.